### PR TITLE
Refactor PolyLog extension into modular architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+PolyLog is a VS Code extension (JavaScript/CommonJS) that inserts language-specific log statements for selected variables. Source code is in `polylog/`. There is no backend, no database, and no running services — it's a pure client-side VS Code extension.
+
+### Commands
+
+All commands run from `polylog/`:
+
+- **Lint**: `npm run lint` — runs ESLint via flat config (`eslint.config.mjs`)
+- **Test**: `npm test` — runs `pretest` (lint) then `vscode-test`, which downloads a VS Code instance and executes integration tests in `test/extension.test.js`. dbus errors in the test output are harmless in headless/container environments.
+- **Package**: `npx @vscode/vsce package --allow-missing-repository --baseImagesUrl https://example.com` — produces a `.vsix` file
+
+### Manual testing
+
+To test the extension interactively in VS Code Extension Development Host:
+
+```
+export DISPLAY=:1
+/workspace/polylog/.vscode-test/vscode-linux-x64-*/bin/code --extensionDevelopmentPath=/workspace/polylog /workspace/polylog/testfiles/test.js
+```
+
+Then select a variable name, press `Ctrl+Shift+A`, pick a log level, and confirm the log statement is inserted.
+
+### Gotchas
+
+- The VS Code test binary is downloaded to `polylog/.vscode-test/` on first `npm test` run. Subsequent runs reuse the cached binary.
+- `@vscode/vsce` is not a project dependency; install globally with `npm install -g @vscode/vsce` if you need to package.
+- The extension's entry point is `polylog/extension.js` (CommonJS, no build step required).

--- a/polylog/eslint.config.mjs
+++ b/polylog/eslint.config.mjs
@@ -1,6 +1,10 @@
 import globals from "globals";
 
-export default [{
+export default [
+{
+    ignores: ["node_modules/**", ".vscode-test/**", "testfiles/**"],
+},
+{
     files: ["**/*.js"],
     languageOptions: {
         globals: {

--- a/polylog/extension.js
+++ b/polylog/extension.js
@@ -1,276 +1,71 @@
 const vscode = require('vscode');
-const fs = require('fs');
-const readline = require('readline');
+const { getLanguageForFile, buildLogStatement, LANGUAGES } = require('./languages');
+const { findScriptBlockRange } = require('./scriptDetector');
 
 function activate(context) {
-    const statusBarItem = initializeStatusBar(context);
+    const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+    statusBarItem.show();
+    context.subscriptions.push(statusBarItem);
 
     const logCommand = vscode.commands.registerCommand('console.log', async () => {
-        await updateLanguage(context, getDefaultLanguage());
-        let userLanguage = await context.globalState.get('selectedLanguage');
-        statusBarItem.text = `$(file-code) Language: ${userLanguage}`;
         const editor = vscode.window.activeTextEditor;
-
-        if (editor) {
-            const selectedText = editor.document.getText(editor.selection);
-            const lineNumber = editor.selection.start.line;
-
-            const line = editor.document.lineAt(lineNumber);
-            const startCharacterPosition = line.firstNonWhitespaceCharacterIndex;
-
-            if (selectedText) {
-                const lineNumber = editor.selection.active.line + 1;
-                await editor.edit(editBuilder => {
-                    if (lineNumber >= editor.document.lineCount) {
-                        editBuilder.insert(editor.document.lineAt(lineNumber - 1).range.end, '\n');
-                    }
-                })
-                const line = editor.document.lineAt(lineNumber);
-                const currentLineText = editor.document.lineAt(editor.selection.active.line).text;
-                
-                if (currentLineText.includes(`${selectedText} =`) ||
-                    currentLineText.includes(`${selectedText}=`)  ||
-                    currentLineText.includes(`${selectedText}:`) ||
-                    currentLineText.includes(`${selectedText} :=`) ||
-                    currentLineText.includes(`${selectedText}:`) ||
-                    currentLineText.includes(`${selectedText} :=`)
-                ) {
-                    let log;
-
-                    if (userLanguage === "JavaScript" || userLanguage === "TypeScript") {
-                        log = await buildLogStatement(userLanguage, selectedText);
-                    } else if (userLanguage === 'Php') {
-                        log = await buildLogStatement(userLanguage, selectedText, lineNumber);
-                    } else if (userLanguage === 'html') {
-                        log = await buildLogStatement(userLanguage, selectedText, lineNumber);
-                    } else if (userLanguage === 'Python') {
-                        log = await buildLogStatement(userLanguage, selectedText);
-                    } else if (userLanguage === 'Java') {
-                        log = await buildLogStatement(userLanguage, selectedText);
-                    } else if (userLanguage === 'Golang') {
-                        log = await buildLogStatement(userLanguage, selectedText);
-                    } else if (userLanguage === 'Dart') {
-                        log = await buildLogStatement(userLanguage, selectedText);
-                    } else {
-                        return vscode.window.showInformationMessage('Language not supported right now!!');
-                    }
-                    if(log){
-                        let intendation = " ".repeat(startCharacterPosition);
-                        
-                        editor.edit(editBuilder => {
-                            editBuilder.insert(line.range.start, `\n${intendation}${log}`);
-                        });
-                    }
-                    else{
-                        vscode.window.showInformationMessage('Please select variable to add logger');
-                    }
-                } else {
-                    vscode.window.showInformationMessage('Please select variable to add logger');
-                }
-
-            } else {
-                vscode.window.showInformationMessage('Please select some text to add logger');
-            }
-        } else {
-            vscode.window.showInformationMessage('No active editor found');
+        if (!editor) {
+            return vscode.window.showInformationMessage('No active editor found');
         }
+
+        const languageName = getLanguageForFile(editor.document.fileName);
+        if (!languageName) {
+            return vscode.window.showInformationMessage('Language not supported right now!!');
+        }
+
+        statusBarItem.text = `$(file-code) Language: ${languageName}`;
+
+        const selectedText = editor.document.getText(editor.selection);
+        if (!selectedText) {
+            return vscode.window.showInformationMessage('Please select some text to add logger');
+        }
+
+        const currentLineText = editor.document.lineAt(editor.selection.active.line).text;
+        if (!isVariableAssignment(currentLineText, selectedText)) {
+            return vscode.window.showInformationMessage('Please select variable to add logger');
+        }
+
+        const indentation = " ".repeat(
+            editor.document.lineAt(editor.selection.start.line).firstNonWhitespaceCharacterIndex
+        );
+
+        const insertLineIndex = editor.selection.active.line + 1;
+        await editor.edit(editBuilder => {
+            if (insertLineIndex >= editor.document.lineCount) {
+                editBuilder.insert(editor.document.lineAt(insertLineIndex - 1).range.end, '\n');
+            }
+        });
+
+        const langConfig = LANGUAGES[languageName];
+        const scriptRange = langConfig.detectsScriptBlock
+            ? findScriptBlockRange(editor.document)
+            : null;
+
+        const log = await buildLogStatement(languageName, selectedText, insertLineIndex, scriptRange);
+        if (!log) {
+            return vscode.window.showInformationMessage('Please select variable to add logger');
+        }
+
+        const insertLine = editor.document.lineAt(insertLineIndex);
+        await editor.edit(editBuilder => {
+            editBuilder.insert(insertLine.range.start, `\n${indentation}${log}`);
+        });
     });
 
     context.subscriptions.push(logCommand);
 }
 
-const readFileLineByLine = async (lineForFile = "Php") => {
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-        vscode.window.showInformationMessage('No active editor found');
-        return;
-    }
-
-    const filePath = editor.document.fileName;
-    const fileStream = fs.createReadStream(filePath);
-
-    const rl = readline.createInterface({
-        input: fileStream,
-        crlfDelay: Infinity
-    });
-
-    let currentLine = 0;
-    let startLine = -1;
-    let endLine = -1;
-
-    for await (const line of rl) {
-        currentLine++;
-        if (lineForFile === "Php") {
-            if (line.includes("<script")) {
-                startLine = currentLine + 1;
-            }
-
-            if (line.includes("</script")) {
-                endLine = currentLine + 1;
-            }
-        }
-    }
-    return {
-        "startLine": startLine,
-        "endLine": endLine
-    };
-};
-
-const buildLogStatement = async (language, logVariable, lineNumber = 0) => {
-    const uniqueId = Date.now();
-    switch (language) {
-        case "JavaScript":
-        case "TypeScript": {
-            const selectLogLevel = await vscode.window.showQuickPick(
-                ["Log", "Warning", "Error"], {
-                    placeHolder: 'Select a log level',
-                    canPickMany: false
-                }
-            ) || "Log";
-
-            const logColor = getLogColor(selectLogLevel);
-            return `console.${selectLogLevel === "Warning" ? "warn" : selectLogLevel.toLowerCase()}('%c[Log #${uniqueId}] ${logVariable}:', 'color: ${logColor}; font-weight: bold;', ${logVariable});\n`;
-        }
-        case "Php": {
-            const lineRange = await readFileLineByLine();
-            if (lineNumber >= lineRange.startLine && lineNumber <= lineRange.endLine) {
-                return buildLogStatement("JavaScript", logVariable);
-            }
-
-            return `echo '[Log #${uniqueId}] ${logVariable}: ', ${logVariable};\n`;
-        }
-        case "html": {
-            const lineRange = await readFileLineByLine();
-            if (lineNumber >= lineRange.startLine && lineNumber <= lineRange.endLine) {
-                return buildLogStatement("JavaScript", logVariable);
-            }
-
-            return;
-        }
-        case "Python":{
-            const selectLogLevel = await vscode.window.showQuickPick(
-                ["Log", "Warning", "Error"], {
-                    placeHolder: 'Select a log level',
-                    canPickMany: false
-                }
-            ) || "Log";
-
-            const pythonLogColor = getXLogColor(selectLogLevel);
-            
-            return `print(f"${pythonLogColor}[Log #${uniqueId}] ${logVariable}: {${logVariable}}{'\\033[0m'}")\n`;
-        }
-        case "Java":{
-            const selectLogLevel = await vscode.window.showQuickPick(
-                ["Log", "Warning", "Error"], {
-                    placeHolder: 'Select a log level',
-                    canPickMany: false
-                }
-            ) || "Log";
-
-            const logLevelMap = {
-                "Log": "System.out.println",
-                "Warning": "System.err.println",
-                "Error": "System.err.println"
-            };
-
-            const javaLogColor = getXLogColor(selectLogLevel);
-
-            return `${logLevelMap[selectLogLevel]}("${javaLogColor}[Log #${uniqueId}] ${logVariable}: " + ${logVariable} + "\\033[0m");\n`;
-        }
-        case 'Golang': {
-            const selectLogLevel = await vscode.window.showQuickPick(
-                ["Log", "Warning", "Error"], {
-                    placeHolder: 'Select a log level',
-                    canPickMany: false
-                }
-            ) || "Log";
-
-            const goLogColor = getXLogColor(selectLogLevel);
-
-            return `fmt.Printf("${goLogColor}[Log #${uniqueId}] ${logVariable}: %v\\033[0m\\n", ${logVariable});\n`;
-        }
-        case 'Dart': {
-            const selectLogLevel = await vscode.window.showQuickPick(
-                ["Log", "Warning", "Error"], {
-                    placeHolder: 'Select a log level',
-                    canPickMany: false
-                }
-            ) || "Log";
-
-            const dartLogColor = getDartLogColor(selectLogLevel);
-            
-            return `print("${dartLogColor}[Log #${uniqueId}] ${logVariable}: $${logVariable}\\x1B[0m");\n`;
-        }
-        default:
-            return `console.log('');`;
-    }
-};
-
-const getXLogColor = (logLevel) => {
-    const Colors = {
-        "Warning": '\\033[93m', // Yellow
-        "Error": '\\033[91m',   // Red
-        "Log": '\\033[97m',     // Green
-    };
-    return Colors[logLevel] || Colors.LOG;
+function isVariableAssignment(lineText, variable) {
+    return lineText.includes(`${variable} =`)
+        || lineText.includes(`${variable}=`)
+        || lineText.includes(`${variable}:`)
+        || lineText.includes(`${variable} :=`);
 }
-
-const getDartLogColor = (logLevel) => {
-    const Colors = {
-        "Warning": '\\x1B[93m', // Yellow
-        "Error": '\\x1B[91m',   // Red
-        "Log": '\\x1B[97m',     // Green
-    };
-    return Colors[logLevel] || Colors.LOG;
-}
-
-const getLogColor = (logLevel) => {
-    switch (logLevel) {
-        case "Error":
-            return "red";
-        case "Warning":
-            return "orange";
-        default:
-            return "green";
-    }
-};
-
-const getDefaultLanguage = () => {
-    const editor = vscode.window.activeTextEditor;
-
-    if (editor) {
-        const fileExtension = editor.document.fileName.split('.').pop().toLowerCase();
-        const languageMap = {
-            js: "JavaScript",
-            php: "Php",
-            html: "html",
-            ts: "TypeScript",
-            py: "Python",
-            java: "Java",
-            go: "Golang",
-            dart: "Dart"
-        };
-
-        return languageMap[fileExtension] || null;
-    } else {
-        vscode.window.showInformationMessage('No active editor found');
-        return null;
-    }
-};
-
-function initializeStatusBar(context) {
-    const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-    statusBarItem.show();
-    context.subscriptions.push(statusBarItem);
-    return statusBarItem;
-}
-
-async function updateLanguage(context, defaultLanguage) {
-    let userLanguage = await context.globalState.get('selectedLanguage');
-    userLanguage = defaultLanguage;
-    await context.globalState.update('selectedLanguage', userLanguage);
-}
-
 
 function deactivate() {}
 

--- a/polylog/languages.js
+++ b/polylog/languages.js
@@ -1,0 +1,125 @@
+const vscode = require('vscode');
+
+const LOG_LEVELS = ["Log", "Warning", "Error"];
+
+const CSS_COLORS = { Log: "green", Warning: "orange", Error: "red" };
+const ANSI_COLORS = { Log: '\\033[97m', Warning: '\\033[93m', Error: '\\033[91m' };
+const DART_COLORS = { Log: '\\x1B[97m', Warning: '\\x1B[93m', Error: '\\x1B[91m' };
+
+async function promptLogLevel() {
+    return await vscode.window.showQuickPick(LOG_LEVELS, {
+        placeHolder: 'Select a log level',
+        canPickMany: false
+    }) || "Log";
+}
+
+function jsLogFormatter(logVariable, uniqueId, logLevel) {
+    const color = CSS_COLORS[logLevel];
+    const method = logLevel === "Warning" ? "warn" : logLevel.toLowerCase();
+    return `console.${method}('%c[Log #${uniqueId}] ${logVariable}:', 'color: ${color}; font-weight: bold;', ${logVariable});\n`;
+}
+
+const LANGUAGES = {
+    JavaScript: {
+        extensions: ['js'],
+        needsLogLevel: true,
+        format(logVariable, uniqueId, logLevel) {
+            return jsLogFormatter(logVariable, uniqueId, logLevel);
+        }
+    },
+    TypeScript: {
+        extensions: ['ts'],
+        needsLogLevel: true,
+        format(logVariable, uniqueId, logLevel) {
+            return jsLogFormatter(logVariable, uniqueId, logLevel);
+        }
+    },
+    Php: {
+        extensions: ['php'],
+        needsLogLevel: false,
+        detectsScriptBlock: true,
+        format(logVariable, uniqueId) {
+            return `echo '[Log #${uniqueId}] ${logVariable}: ', ${logVariable};\n`;
+        }
+    },
+    html: {
+        extensions: ['html'],
+        needsLogLevel: false,
+        detectsScriptBlock: true,
+        format() {
+            return undefined;
+        }
+    },
+    Python: {
+        extensions: ['py'],
+        needsLogLevel: true,
+        format(logVariable, uniqueId, logLevel) {
+            const color = ANSI_COLORS[logLevel];
+            return `print(f"${color}[Log #${uniqueId}] ${logVariable}: {${logVariable}}{'\\033[0m'}")\n`;
+        }
+    },
+    Java: {
+        extensions: ['java'],
+        needsLogLevel: true,
+        format(logVariable, uniqueId, logLevel) {
+            const method = logLevel === "Log" ? "System.out.println" : "System.err.println";
+            const color = ANSI_COLORS[logLevel];
+            return `${method}("${color}[Log #${uniqueId}] ${logVariable}: " + ${logVariable} + "\\033[0m");\n`;
+        }
+    },
+    Golang: {
+        extensions: ['go'],
+        needsLogLevel: true,
+        format(logVariable, uniqueId, logLevel) {
+            const color = ANSI_COLORS[logLevel];
+            return `fmt.Printf("${color}[Log #${uniqueId}] ${logVariable}: %v\\033[0m\\n", ${logVariable});\n`;
+        }
+    },
+    Dart: {
+        extensions: ['dart'],
+        needsLogLevel: true,
+        format(logVariable, uniqueId, logLevel) {
+            const color = DART_COLORS[logLevel];
+            return `print("${color}[Log #${uniqueId}] ${logVariable}: $${logVariable}\\x1B[0m");\n`;
+        }
+    }
+};
+
+const EXTENSION_TO_LANGUAGE = {};
+for (const [name, config] of Object.entries(LANGUAGES)) {
+    for (const ext of config.extensions) {
+        EXTENSION_TO_LANGUAGE[ext] = name;
+    }
+}
+
+function getLanguageForFile(fileName) {
+    const ext = fileName.split('.').pop().toLowerCase();
+    return EXTENSION_TO_LANGUAGE[ext] || null;
+}
+
+async function buildLogStatement(languageName, logVariable, lineNumber, scriptRange) {
+    const config = LANGUAGES[languageName];
+    if (!config) {
+        return null;
+    }
+
+    const uniqueId = Date.now();
+
+    if (config.detectsScriptBlock && scriptRange) {
+        const inScript = lineNumber >= scriptRange.startLine && lineNumber <= scriptRange.endLine;
+        if (inScript) {
+            return buildLogStatement("JavaScript", logVariable, lineNumber, null);
+        }
+        return config.format(logVariable, uniqueId);
+    }
+
+    const logLevel = config.needsLogLevel ? await promptLogLevel() : undefined;
+    return config.format(logVariable, uniqueId, logLevel);
+}
+
+module.exports = {
+    LANGUAGES,
+    getLanguageForFile,
+    buildLogStatement,
+    promptLogLevel
+};

--- a/polylog/package-lock.json
+++ b/polylog/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "console",
+  "name": "polylog",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "console",
+      "name": "polylog",
       "version": "0.0.1",
       "devDependencies": {
         "@types/mocha": "^10.0.9",

--- a/polylog/scriptDetector.js
+++ b/polylog/scriptDetector.js
@@ -1,0 +1,26 @@
+/**
+ * Detects the last <script>...</script> block range in the active editor's
+ * document using the VS Code document API instead of re-reading the file
+ * from disk.
+ *
+ * Returns { startLine, endLine } with 1-based line numbers matching the
+ * original contract, or { startLine: -1, endLine: -1 } if no block is found.
+ */
+function findScriptBlockRange(document) {
+    let startLine = -1;
+    let endLine = -1;
+
+    for (let i = 0; i < document.lineCount; i++) {
+        const text = document.lineAt(i).text;
+        if (text.includes("<script")) {
+            startLine = i + 2;
+        }
+        if (text.includes("</script")) {
+            endLine = i + 2;
+        }
+    }
+
+    return { startLine, endLine };
+}
+
+module.exports = { findScriptBlockRange };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refactors the monolithic `extension.js` (281 lines) into a clean, modular architecture with three focused files.

### Changes

**New files:**
- `languages.js` — Data-driven language configuration: extension-to-language mapping, color maps (CSS, ANSI, Dart), log formatters, and a single shared `promptLogLevel()` replacing 5 copy-pasted `showQuickPick` calls
- `scriptDetector.js` — `<script>` block detection using the VS Code document API (replaces `fs.createReadStream` which re-read the already-open file from disk)

**Refactored:**
- `extension.js` — Reduced from 281 to 75 lines. Flattened 4+ levels of nesting, eliminated duplicated if/else-if chain (7 branches all calling the same function), removed duplicate condition checks, extracted `isVariableAssignment` helper
- `eslint.config.mjs` — Added `ignores` for `node_modules/`, `.vscode-test/`, and `testfiles/` (fixes OOM crash when `.vscode-test` contains a full VS Code installation)

**Also:**
- `AGENTS.md` — Cursor Cloud specific instructions for development
- `package-lock.json` — Fixed stale `name` field (`"console"` → `"polylog"`)

### Key improvements

| Before | After |
|--------|-------|
| 281 lines, single file | 75 + 115 + 25 lines across 3 focused modules |
| 5× copy-pasted `showQuickPick` | Single shared `promptLogLevel()` |
| 7-branch if/else-if calling same function | Data-driven lookup via `LANGUAGES` config |
| `fs.createReadStream` to re-read open file | `document.lineAt()` via VS Code API |
| Duplicate conditions (lines 33≡35, 34≡36) | Deduplicated in `isVariableAssignment()` |
| 4+ levels of nesting | Early-return flat flow |
| ESLint OOM when `.vscode-test` present | Explicit `ignores` in flat config |

### Testing

| Check | Result |
|-------|--------|
| `npm run lint` (ESLint) | Passes clean |
| `npm test` (vscode-test integration) | 1/1 passing |
| Manual: JS Warning-level log | `console.warn` with orange styling inserted correctly |
| Manual: Python Error-level log | `print()` with ANSI red inserted correctly |

### Demo

[refactored_polylog_js_and_python_test.mp4](https://cursor.com/agents/bc-cfd29333-de51-44ab-9f53-41d11ef34b05/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frefactored_polylog_js_and_python_test.mp4)

Testing the refactored extension across JavaScript (Warning level) and Python (Error level) — variable detection, log level picker, and language-specific log statement insertion all work correctly.

[JavaScript warning log statement inserted](https://cursor.com/agents/bc-cfd29333-de51-44ab-9f53-41d11ef34b05/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjs_warning_log_inserted.webp)
[Python error print statement inserted](https://cursor.com/agents/bc-cfd29333-de51-44ab-9f53-41d11ef34b05/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpython_error_log_inserted.webp)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfd29333-de51-44ab-9f53-41d11ef34b05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfd29333-de51-44ab-9f53-41d11ef34b05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

